### PR TITLE
chore: fix casing in the URL of the repo

### DIFF
--- a/.changeset/tall-feet-hear.md
+++ b/.changeset/tall-feet-hear.md
@@ -1,0 +1,9 @@
+---
+"@workleap/browserslist-config": patch
+"@workleap/typescript-configs": patch
+"@workleap/stylelint-config": patch
+"@workleap/postcss-plugin": patch
+"@workleap/eslint-plugin": patch
+---
+
+Updated package.json's repository url

--- a/.changeset/tall-feet-hear.md
+++ b/.changeset/tall-feet-hear.md
@@ -1,9 +1,0 @@
----
-"@workleap/browserslist-config": patch
-"@workleap/typescript-configs": patch
-"@workleap/stylelint-config": patch
-"@workleap/postcss-plugin": patch
-"@workleap/eslint-plugin": patch
----
-
-Updated package.json's repository url

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Workleap/wl-web-configs"
+        "url": "git+https://github.com/workleap/wl-web-configs"
     },
     "scripts": {
         "build": "pnpm -r build",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/workleap/wl-web-configs"
+        "url": "git+https://github.com/workleap/wl-web-configs.git"
     },
     "scripts": {
         "build": "pnpm -r build",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -10,7 +10,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs.git",
         "directory": "packages/browserslist-config"
     },
     "main": "./dist/index.js",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -10,7 +10,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs",
         "directory": "packages/browserslist-config"
     },
     "main": "./dist/index.js",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -13,7 +13,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs.git",
         "directory": "packages/eslint-plugin"
     },
     "license": "Apache-2.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -13,7 +13,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs",
         "directory": "packages/eslint-plugin"
     },
     "license": "Apache-2.0",

--- a/packages/postcss-plugin/package.json
+++ b/packages/postcss-plugin/package.json
@@ -12,7 +12,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs",
         "directory": "packages/postcss-plugin"
     },
     "main": "./dist/index.js",

--- a/packages/postcss-plugin/package.json
+++ b/packages/postcss-plugin/package.json
@@ -12,7 +12,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs.git",
         "directory": "packages/postcss-plugin"
     },
     "main": "./dist/index.js",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -20,7 +20,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs",
         "directory": "packages/stylelint-config"
     },
     "scripts": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -20,7 +20,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs.git",
         "directory": "packages/stylelint-config"
     },
     "scripts": {

--- a/packages/typescript-configs/package.json
+++ b/packages/typescript-configs/package.json
@@ -12,7 +12,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs",
         "directory": "packages/typescript-configs"
     },
     "publishConfig": {

--- a/packages/typescript-configs/package.json
+++ b/packages/typescript-configs/package.json
@@ -12,7 +12,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/workleap/wl-web-configs",
+        "url": "git+https://github.com/workleap/wl-web-configs.git",
         "directory": "packages/typescript-configs"
     },
     "publishConfig": {


### PR DESCRIPTION
error an error occurred while publishing @workleap/eslint-plugin: E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/@workleap%2feslint-plugin - Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/Workleap/wl-web-configs.git", expected to match "git+https://github.com/workleap/wl-web-configs" from provenance 
