### PR TITLE
feat(eslint-plugin): Updated configuration settings to improve error handling: Removed overwrites of all errors in the old configuration, resulting in errors now being flagged as errors instead of appearing as warnings.

### DIFF
--- a/.changeset/modern-games-breathe.md
+++ b/.changeset/modern-games-breathe.md
@@ -1,0 +1,5 @@
+---
+"@workleap/eslint-plugin": minor
+---
+
+test

--- a/packages/eslint-plugin/lib/config/core.ts
+++ b/packages/eslint-plugin/lib/config/core.ts
@@ -13,80 +13,31 @@ const config: Linter.Config = {
         es6: true
     },
     rules: {
-        // eslint:recommended warn instead of error
-        "no-const-assign": "warn",
-        "no-control-regex": "warn",
-        "no-debugger": "warn",
-        "no-delete-var": "warn",
-        "no-dupe-args": "warn",
-        "no-dupe-class-members": "warn",
-        "no-dupe-keys": "warn",
-        "no-duplicate-case": "warn",
-        "no-empty-character-class": "warn",
-        "no-empty-pattern": "warn",
-        "no-ex-assign": "warn",
-        "no-fallthrough": "warn",
-        "no-func-assign": "warn",
-        "no-invalid-regexp": "warn",
-        "no-new-symbol": "warn",
-        "no-obj-calls": "warn",
-        "no-octal": "warn",
-        "no-regex-spaces": "warn",
-        "no-self-assign": "warn",
-        "no-shadow-restricted-names": "warn",
-        "no-sparse-arrays": "warn",
-        "no-this-before-super": "warn",
-        "no-undef": "error",
-        "no-unexpected-multiline": "warn",
-        "no-unreachable": "warn",
-        "no-unused-labels": "warn",
-        "no-useless-escape": "warn",
-        "no-with": "warn",
-        "require-yield": "warn",
-        "use-isnan": "warn",
-        "valid-typeof": "warn",
-        "getter-return": "warn",
-        "no-unused-vars": "warn",
-
-        "constructor-super": "warn",
-        "for-direction": "warn",
-        "no-async-promise-executor": "warn",
-        "no-case-declarations": "warn",
-        "no-class-assign": "warn",
-        "no-compare-neg-zero": "warn",
-        "no-constant-condition": "warn",
-        "no-dupe-else-if": "warn",
-        "no-empty": "warn",
-        "no-extra-boolean-cast": "warn",
-        "no-extra-semi": "warn",
-        "no-global-assign": "warn",
-        "no-import-assign": "warn",
-        "no-inner-declarations": "warn",
-        "no-irregular-whitespace": "warn",
-        "no-loss-of-precision": "warn",
-        "no-misleading-character-class": "warn",
-        "no-mixed-spaces-and-tabs": "warn",
-        "no-nonoctal-decimal-escape": "warn",
-        "no-redeclare": "warn",
-        "no-setter-return": "warn",
-        "no-unsafe-finally": "warn",
-        "no-unsafe-negation": "warn",
-        "no-unsafe-optional-chaining": "warn",
-        "no-useless-backreference": "warn",
-        "no-useless-catch": "warn",
-
         // eslint:recommended overwrite some rules
-        "no-cond-assign": ["warn", "except-parens"],
+        "no-cond-assign": ["error", "except-parens"],
         "no-labels": ["warn", { allowLoop: true, allowSwitch: false }],
         "no-prototype-builtins": "off",
 
         // https://eslint.org/docs/rules
         // Extra eslint rules
+
+        // Possible Problems
+        "array-callback-return": "error",
+        "no-self-compare": "error",
+        "no-template-curly-in-string": "error",
+        "no-use-before-define": [
+            "error",
+            {
+                functions: false,
+                classes: false,
+                variables: false
+            }
+        ],
+
+        // Suggestions
         "no-array-constructor": "warn",
         "no-caller": "warn",
         "no-eval": "warn",
-        "new-parens": "warn",
-        "array-callback-return": "warn",
         "no-extend-native": "warn",
         "no-extra-bind": "warn",
         "no-extra-label": "warn",
@@ -96,8 +47,6 @@ const config: Linter.Config = {
         "no-lone-blocks": "warn",
         "no-loop-func": "warn",
         "no-multi-str": "warn",
-        "no-native-reassign": "warn",
-        "no-negated-in-lhs": "warn",
         "no-new-func": "warn",
         "no-new-object": "warn",
         "no-new-wrappers": "warn",
@@ -105,20 +54,47 @@ const config: Linter.Config = {
         "no-useless-computed-key": "warn",
         "no-useless-concat": "warn",
         "no-useless-constructor": "warn",
-        "no-whitespace-before-property": "warn",
         "no-script-url": "warn",
-        "no-self-compare": "warn",
         "no-sequences": "warn",
-        "no-template-curly-in-string": "warn",
         "no-throw-literal": "warn",
         "prefer-const": "warn",
         "no-var": "warn",
-        "no-multi-spaces": "warn",
         "curly": "warn",
         "no-shadow": "warn",
         "no-restricted-properties": "warn",
         "no-unneeded-ternary": "warn",
         "no-param-reassign": "warn",
+        "eqeqeq": ["warn", "smart"],
+        "no-mixed-operators": [
+            "warn",
+            {
+                groups: [
+                    ["&", "|", "^", "~", "<<", ">>", ">>>"],
+                    ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+                    ["&&", "||"],
+                    ["in", "instanceof"]
+                ],
+                allowSamePrecedence: false
+            }
+        ],
+        "no-restricted-syntax": ["error", "WithStatement"],
+        "no-restricted-globals": ["error"],
+        "no-useless-rename": [
+            "warn",
+            {
+                ignoreDestructuring: false,
+                ignoreImport: false,
+                ignoreExport: false
+            }
+        ],
+        "strict": ["warn", "never"],
+
+        // Layout & Formatting
+        "new-parens": "warn",
+        "no-native-reassign": "warn",
+        "no-negated-in-lhs": "warn",
+        "no-whitespace-before-property": "warn",
+        "no-multi-spaces": "warn",
         "no-multiple-empty-lines": "warn",
         "space-infix-ops": "warn",
         "max-len": ["warn", { tabWidth: 4, code: 300 }],
@@ -135,22 +111,7 @@ const config: Linter.Config = {
         "comma-dangle": ["warn", "never"],
         "object-curly-spacing": ["warn", "always"],
         "dot-location": ["warn", "property"],
-        "eqeqeq": ["warn", "smart"],
         "arrow-parens": ["warn", "as-needed"],
-        "no-mixed-operators": [
-            "warn",
-            {
-                groups: [
-                    ["&", "|", "^", "~", "<<", ">>", ">>>"],
-                    ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
-                    ["&&", "||"],
-                    ["in", "instanceof"]
-                ],
-                allowSamePrecedence: false
-            }
-        ],
-        "no-restricted-syntax": ["warn", "WithStatement"],
-        "no-restricted-globals": ["error"],
         "no-unused-expressions": [
             "error",
             {
@@ -159,24 +120,7 @@ const config: Linter.Config = {
                 allowTaggedTemplates: true
             }
         ],
-        "no-use-before-define": [
-            "warn",
-            {
-                functions: false,
-                classes: false,
-                variables: false
-            }
-        ],
-        "no-useless-rename": [
-            "warn",
-            {
-                ignoreDestructuring: false,
-                ignoreImport: false,
-                ignoreExport: false
-            }
-        ],
         "rest-spread-spacing": ["warn", "never"],
-        "strict": ["warn", "never"],
         "unicode-bom": ["warn", "never"],
         "padding-line-between-statements": [
             "warn",

--- a/packages/eslint-plugin/lib/config/core.ts
+++ b/packages/eslint-plugin/lib/config/core.ts
@@ -88,11 +88,33 @@ const config: Linter.Config = {
             }
         ],
         "strict": ["warn", "never"],
+        "no-unused-expressions": [
+            "error",
+            {
+                allowShortCircuit: true,
+                allowTernary: true,
+                allowTaggedTemplates: true
+            }
+        ],
 
         // Layout & Formatting
+        "no-native-reassign": "warn", // deprecated replaced by no-global-assign, deja ds recommended
+        "no-negated-in-lhs": "warn", // deprecated replaced by no-unsafe-negation, deja ds recommended
+        "padding-line-between-statements": [
+            "warn",
+            { blankLine: "always", prev: "*", next: "return" }
+        ],
+
+        "rest-spread-spacing": ["warn", "never"],
+        "unicode-bom": ["warn", "never"],
+        "comma-spacing": ["warn", { "before": false, "after": true }],
+        "keyword-spacing": ["warn", { before: true, after: true }],
+        "arrow-spacing": ["warn", { before: true, after: true }],
+        "space-before-blocks": ["warn", "always"],
+        "space-in-parens": ["warn", "never"],
+        "padded-blocks": ["warn", "never"],
+        "brace-style":["warn", "1tbs", { "allowSingleLine": true }],
         "new-parens": "warn",
-        "no-native-reassign": "warn",
-        "no-negated-in-lhs": "warn",
         "no-whitespace-before-property": "warn",
         "no-multi-spaces": "warn",
         "no-multiple-empty-lines": "warn",
@@ -112,27 +134,6 @@ const config: Linter.Config = {
         "object-curly-spacing": ["warn", "always"],
         "dot-location": ["warn", "property"],
         "arrow-parens": ["warn", "as-needed"],
-        "no-unused-expressions": [
-            "error",
-            {
-                allowShortCircuit: true,
-                allowTernary: true,
-                allowTaggedTemplates: true
-            }
-        ],
-        "rest-spread-spacing": ["warn", "never"],
-        "unicode-bom": ["warn", "never"],
-        "padding-line-between-statements": [
-            "warn",
-            { blankLine: "always", prev: "*", next: "return" }
-        ],
-        "comma-spacing": ["warn", { "before": false, "after": true }],
-        "keyword-spacing": ["warn", { before: true, after: true }],
-        "arrow-spacing": ["warn", { before: true, after: true }],
-        "space-before-blocks": ["warn", "always"],
-        "space-in-parens": ["warn", "never"],
-        "padded-blocks": ["warn", "never"],
-        "brace-style":["warn", "1tbs", { "allowSingleLine": true }],
 
         // https://github.com/import-js/eslint-plugin-import/tree/main/docs/rules
         "import/no-amd": "error",

--- a/packages/eslint-plugin/lib/config/jest.ts
+++ b/packages/eslint-plugin/lib/config/jest.ts
@@ -14,30 +14,9 @@ const config: Linter.Config = {
             extends: ["plugin:jest/recommended"],
             rules: {
                 // Prefer spies to allow for automatic restoration
-                "jest/prefer-spy-on": "warn",
+                "jest/prefer-spy-on": "error",
                 // Gives better failure messages for array checks
-                "jest/prefer-to-contain": "warn",
-
-                // like jest/recommended, but set severity to warning
-                "jest/expect-expect": "warn",
-                "jest/no-alias-methods": "warn",
-                "jest/no-commented-out-tests": "warn",
-                "jest/no-conditional-expect": "warn",
-                "jest/no-deprecated-functions": "warn",
-                "jest/no-disabled-tests": "warn",
-                "jest/no-done-callback": "warn",
-                "jest/no-export": "warn",
-                "jest/no-focused-tests": "warn",
-                "jest/no-identical-title": "warn",
-                "jest/no-interpolation-in-snapshots": "warn",
-                "jest/no-jasmine-globals": "warn",
-                "jest/no-mocks-import": "warn",
-                "jest/no-standalone-expect": "warn",
-                "jest/no-test-prefixes": "warn",
-                "jest/valid-describe-callback": "warn",
-                "jest/valid-expect": "warn",
-                "jest/valid-expect-in-promise": "warn",
-                "jest/valid-title": "warn"
+                "jest/prefer-to-contain": "error"
             }
         }
     ]

--- a/packages/eslint-plugin/lib/config/react.ts
+++ b/packages/eslint-plugin/lib/config/react.ts
@@ -27,24 +27,6 @@ const config: Linter.Config = {
                 // https://eslint.org/docs/rules
                 "jsx-quotes": ["warn", "prefer-double"],
 
-                // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules
-                // react/recommended warn instead of error
-                "react/jsx-no-comment-textnodes": "warn",
-                "react/jsx-no-target-blank": "warn",
-                "react/jsx-uses-react": "warn",
-                "react/jsx-uses-vars": "warn",
-                "react/no-danger-with-children": "warn",
-                "react/no-direct-mutation-state": "warn",
-                "react/no-is-mounted": "warn",
-                "react/require-render-return": "warn",
-                "react/no-unknown-property": "warn",
-                "react/no-children-prop": "warn",
-                "react/no-deprecated": "warn",
-                "react/no-find-dom-node": "warn",
-                "react/no-render-return-value": "warn",
-                "react/no-string-refs": "warn",
-                "react/no-unsafe": "warn",
-
                 // react/recommended overrides
                 "react/jsx-no-duplicate-props": ["warn", { ignoreCase: true }],
                 "react/jsx-no-undef": ["warn", { allowGlobals: true }],
@@ -115,12 +97,7 @@ const config: Linter.Config = {
                 "jsx-a11y/no-redundant-roles": "warn",
                 "jsx-a11y/role-has-required-aria-props": "warn",
                 "jsx-a11y/role-supports-aria-props": "warn",
-                "jsx-a11y/scope": "warn",
-
-                // https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks
-                // react-hooks/recommended warn instead of error
-                "react-hooks/exhaustive-deps": "warn",
-                "react-hooks/rules-of-hooks": "warn"
+                "jsx-a11y/scope": "warn"
             }
         }
     ]

--- a/packages/eslint-plugin/lib/config/react.ts
+++ b/packages/eslint-plugin/lib/config/react.ts
@@ -56,21 +56,22 @@ const config: Linter.Config = {
                     { ignoreClassFields: true }
                 ],
                 "react/jsx-boolean-value": ["warn", "never"],
-                "react/jsx-closing-bracket-location": [1, "line-aligned"],
                 "react/default-props-match-prop-types": "warn",
                 "react/no-unused-state": "warn",
                 "react/no-array-index-key": "warn",
                 "react/no-access-state-in-setstate": "warn",
                 "react/jsx-filename-extension": ["warn", { "extensions": [".jsx", ".tsx"] }],
-                "react/jsx-tag-spacing": ["warn", { beforeSelfClosing: "always" }],
                 "react/jsx-curly-brace-presence": "warn",
-                "react/jsx-max-props-per-line": [
-                    "warn",
-                    { maximum: 1, when: "multiline" }
-                ],
                 "react/no-unused-prop-types": [
                     "warn",
                     { customValidators: [], skipShapeProps: true }
+                ],
+
+                "react/jsx-closing-bracket-location": [1, "line-aligned"],
+                "react/jsx-tag-spacing": ["warn", { beforeSelfClosing: "always" }],
+                "react/jsx-max-props-per-line": [
+                    "warn",
+                    { maximum: 1, when: "multiline" }
                 ],
                 "react/jsx-curly-spacing": ["warn", { children: true, when: "never" }],
 

--- a/packages/eslint-plugin/lib/config/storybook.ts
+++ b/packages/eslint-plugin/lib/config/storybook.ts
@@ -12,27 +12,7 @@ const config: Linter.Config = {
                 "plugin:storybook/recommended",
                 "plugin:storybook/csf",
                 "plugin:storybook/csf-strict"
-            ],
-            rules: {
-                // recommended https://github.com/storybookjs/eslint-plugin-storybook/blob/main/lib/configs/recommended.ts
-                "import/no-anonymous-default-export": "off",
-                "storybook/await-interactions": "warn",
-                "storybook/context-in-play-function": "warn",
-                "storybook/default-exports": "warn",
-                "storybook/hierarchy-separator": "warn",
-                "storybook/no-redundant-story-name": "warn",
-                "storybook/prefer-pascal-case": "warn",
-                "storybook/story-exports": "warn",
-                "storybook/use-storybook-expect": "warn",
-                "storybook/use-storybook-testing-library": "warn",
-
-                // csf https://github.com/storybookjs/eslint-plugin-storybook/blob/main/lib/configs/csf.ts
-                "storybook/csf-component": "warn",
-
-                // csf-strict https://github.com/storybookjs/eslint-plugin-storybook/blob/main/lib/configs/csf-strict.ts
-                "storybook/no-stories-of": "warn",
-                "storybook/no-title-property-in-meta": "warn"
-            }
+            ]
         },
         {
             files: mainStorybookFiles,

--- a/packages/eslint-plugin/lib/config/testing-library.ts
+++ b/packages/eslint-plugin/lib/config/testing-library.ts
@@ -6,46 +6,11 @@ const config: Linter.Config = {
         {
             files: reactTestFiles,
             plugins: ["testing-library"],
-            extends: ["plugin:testing-library/react"],
-            rules: {
-                "testing-library/await-async-query": "warn",
-                "testing-library/await-async-utils": "warn",
-                "testing-library/no-await-sync-query": "warn",
-                "testing-library/no-container": "warn",
-                "testing-library/no-debugging-utils": "warn",
-                "testing-library/no-dom-import": ["warn", "react"],
-                "testing-library/no-node-access": "warn",
-                "testing-library/no-promise-in-fire-event": "warn",
-                "testing-library/no-render-in-setup": "warn",
-                "testing-library/no-unnecessary-act": "warn",
-                "testing-library/no-wait-for-empty-callback": "warn",
-                "testing-library/no-wait-for-multiple-assertions": "warn",
-                "testing-library/no-wait-for-side-effects": "warn",
-                "testing-library/no-wait-for-snapshot": "warn",
-                "testing-library/prefer-find-by": "warn",
-                "testing-library/prefer-presence-queries": "warn",
-                "testing-library/prefer-query-by-disappearance": "warn",
-                "testing-library/prefer-screen-queries": "warn",
-                "testing-library/render-result-naming-convention": "warn"
-            }
+            extends: ["plugin:testing-library/react"]
         },
         {
             files: testFiles,
-            extends: ["plugin:testing-library/dom"],
-            rules: {
-                "testing-library/await-async-query": "warn",
-                "testing-library/await-async-utils": "warn",
-                "testing-library/no-await-sync-query": "warn",
-                "testing-library/no-promise-in-fire-event": "warn",
-                "testing-library/no-wait-for-empty-callback": "warn",
-                "testing-library/no-wait-for-multiple-assertions": "warn",
-                "testing-library/no-wait-for-side-effects": "warn",
-                "testing-library/no-wait-for-snapshot": "warn",
-                "testing-library/prefer-find-by": "warn",
-                "testing-library/prefer-presence-queries": "warn",
-                "testing-library/prefer-query-by-disappearance": "warn",
-                "testing-library/prefer-screen-queries": "warn"
-            }
+            extends: ["plugin:testing-library/dom"]
         }
     ]
 };

--- a/packages/eslint-plugin/lib/config/typescript.ts
+++ b/packages/eslint-plugin/lib/config/typescript.ts
@@ -12,27 +12,6 @@ const config: Linter.Config = {
                 "plugin:@typescript-eslint/recommended"
             ],
             rules: {
-                // @typescript-eslint/recommended but warn instead of errors
-                "@typescript-eslint/ban-ts-comment": "warn",
-                "@typescript-eslint/ban-types": "warn",
-                "@typescript-eslint/no-array-constructor": "warn",
-                "@typescript-eslint/no-empty-function": "warn",
-                "@typescript-eslint/no-empty-interface": "warn",
-                "@typescript-eslint/no-extra-non-null-assertion": "warn",
-                "@typescript-eslint/no-extra-semi": "warn",
-                "@typescript-eslint/no-inferrable-types": "warn",
-                "@typescript-eslint/no-misused-new": "warn",
-                "@typescript-eslint/no-namespace": "warn",
-                "@typescript-eslint/no-non-null-asserted-optional-chain": "warn",
-                "@typescript-eslint/no-this-alias": "warn",
-                "@typescript-eslint/no-var-requires": "warn",
-                "@typescript-eslint/prefer-as-const": "warn",
-                "@typescript-eslint/prefer-namespace-keyword": "warn",
-                "@typescript-eslint/triple-slash-reference": "warn",
-                "@typescript-eslint/adjacent-overload-signatures": "warn",
-                "@typescript-eslint/no-loss-of-precision": "warn",
-                "@typescript-eslint/no-unnecessary-type-constraint": "warn",
-
                 // @typescript-eslint/recommended disables
                 "@typescript-eslint/no-non-null-assertion": "off",
 
@@ -54,7 +33,7 @@ const config: Linter.Config = {
                     }
                 ],
                 "no-dupe-class-members":"off",
-                "@typescript-eslint/no-dupe-class-members":"warn",
+                "@typescript-eslint/no-dupe-class-members":"error",
                 "no-loop-func":"off",
                 "@typescript-eslint/no-loop-func":"warn",
                 "no-shadow":"off",

--- a/packages/eslint-plugin/lib/config/typescript.ts
+++ b/packages/eslint-plugin/lib/config/typescript.ts
@@ -16,22 +16,11 @@ const config: Linter.Config = {
                 "@typescript-eslint/no-non-null-assertion": "off",
 
                 // additional rules we want
-                "@typescript-eslint/member-delimiter-style": "warn",
                 "@typescript-eslint/consistent-type-definitions": "warn",
                 "@typescript-eslint/no-implicit-any-catch": "warn",
                 "@typescript-eslint/explicit-member-accessibility": ["warn", { accessibility: "no-public" }],
                 "@typescript-eslint/method-signature-style": "warn",
                 "comma-dangle":"off",
-                "@typescript-eslint/comma-dangle": ["warn", "never"],
-                "indent":"off",
-                "@typescript-eslint/indent": [
-                    "warn",
-                    4,
-                    {
-                        SwitchCase: 1,
-                        CallExpression: { arguments: "first" }
-                    }
-                ],
                 "no-dupe-class-members":"off",
                 "@typescript-eslint/no-dupe-class-members":"error",
                 "no-loop-func":"off",
@@ -51,12 +40,8 @@ const config: Linter.Config = {
                 "no-useless-constructor":"off",
                 "@typescript-eslint/no-useless-constructor":"warn",
                 "object-curly-spacing":"off",
-                "@typescript-eslint/object-curly-spacing": ["warn", "always"],
                 "quotes":"off",
                 "@typescript-eslint/quotes": ["warn", "double"],
-                "semi":"off",
-                "@typescript-eslint/semi": ["warn", "always"],
-
                 "@typescript-eslint/no-import-type-side-effects": "warn",
                 "@typescript-eslint/consistent-type-imports": [
                     "warn",
@@ -65,7 +50,22 @@ const config: Linter.Config = {
                         "disallowTypeAnnotations": true,
                         "fixStyle": "inline-type-imports"
                     }
-                ]
+                ],
+
+                "@typescript-eslint/member-delimiter-style": "warn",
+                "@typescript-eslint/comma-dangle": ["warn", "never"],
+                "indent":"off",
+                "@typescript-eslint/indent": [
+                    "warn",
+                    4,
+                    {
+                        SwitchCase: 1,
+                        CallExpression: { arguments: "first" }
+                    }
+                ],
+                "@typescript-eslint/object-curly-spacing": ["warn", "always"],
+                "semi":"off",
+                "@typescript-eslint/semi": ["warn", "always"]
             }
         }
     ]


### PR DESCRIPTION
Closes #50 

For a long time, when using CRA, if we had errors, it would stop the linting and only display the most recent error instead of listing them all.

In order to be able to see all the eslint errors in the dev server, we changed all our errors to warnings instead. This way eslint lists all the lint warning instead of only the first one.

Now that we are back to using eslint's cli, i don't think we should use "warn" anymore for our configs. We should extends eslint:recommended, and add our custom rules as errors