### PR TITLE
[Suggestion] Add eslint rule for React compiler (warn)

### DIFF
--- a/.changeset/violet-zebras-dance.md
+++ b/.changeset/violet-zebras-dance.md
@@ -1,0 +1,5 @@
+---
+"@workleap/eslint-plugin": minor
+---
+
+Add react-compiler eslint rules (warn) to the react-library config of workleap/eslint-plugin

--- a/packages/eslint-plugin/lib/config/react.ts
+++ b/packages/eslint-plugin/lib/config/react.ts
@@ -5,10 +5,10 @@ const config: Linter.Config = {
     overrides: [
         {
             files: sourceFiles,
-            plugins: ["react", "react-hooks"],
+            plugins: ["react", "react-hooks", "react-compiler"],
             extends: [
                 "plugin:react/recommended",
-                "plugin:react-hooks/recommended"
+                "plugin:react-hooks/recommended",
             ],
             parserOptions: {
                 ecmaFeatures: {
@@ -76,8 +76,10 @@ const config: Linter.Config = {
                     "warn",
                     { maximum: 1, when: "multiline" }
                 ],
-                "react/jsx-curly-spacing": ["warn", { children: true, when: "never" }]
+                "react/jsx-curly-spacing": ["warn", { children: true, when: "never" }],
 
+                // react-compiler (beta)
+                "react-compiler/require-compiler": "warn"
             }
         }
     ]

--- a/packages/eslint-plugin/lib/config/react.ts
+++ b/packages/eslint-plugin/lib/config/react.ts
@@ -79,7 +79,7 @@ const config: Linter.Config = {
                 "react/jsx-curly-spacing": ["warn", { children: true, when: "never" }],
 
                 // react-compiler (beta)
-                "react-compiler/require-compiler": "warn"
+                "react-compiler/react-compiler": "warn"
             }
         }
     ]

--- a/packages/eslint-plugin/lib/config/react.ts
+++ b/packages/eslint-plugin/lib/config/react.ts
@@ -8,7 +8,7 @@ const config: Linter.Config = {
             plugins: ["react", "react-hooks", "react-compiler"],
             extends: [
                 "plugin:react/recommended",
-                "plugin:react-hooks/recommended",
+                "plugin:react-hooks/recommended"
             ],
             parserOptions: {
                 ecmaFeatures: {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -57,6 +57,7 @@
         "eslint-plugin-mdx": "^3.3.1",
         "eslint-plugin-package-json": "^0.29.0",
         "eslint-plugin-react": "^7.37.4",
+        "eslint-plugin-react-compiler": "19.0.0-beta-ebf51a3-20250411",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-storybook": "^0.12.0",
         "eslint-plugin-testing-library": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       eslint-plugin-react:
         specifier: ^7.37.4
         version: 7.37.4(eslint@8.57.0)
+      eslint-plugin-react-compiler:
+        specifier: 19.0.0-beta-ebf51a3-20250411
+        version: 19.0.0-beta-ebf51a3-20250411(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.57.0)
@@ -722,7 +725,7 @@ importers:
         version: 8.6.11(prettier@3.5.3)
       storybook-react-rsbuild:
         specifier: 1.0.1
-        version: 1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0(@swc/helpers@0.5.15))(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0(esbuild@0.25.2))
+        version: 1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0(@swc/helpers@0.5.15))(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -789,10 +792,10 @@ importers:
         version: 8.6.11(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: 1.0.1
-        version: 1.0.1(@rsbuild/core@1.3.1)(@rslib/core@0.6.1(typescript@5.8.2))(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@types/react@19.0.12)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2))(typescript@5.8.2)
+        version: 1.0.1(@rsbuild/core@1.3.1)(@rslib/core@0.6.1(typescript@5.8.2))(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0)(@types/react@19.0.12)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2))(typescript@5.8.2)
       storybook-react-rsbuild:
         specifier: 1.0.1
-        version: 1.0.1(@rsbuild/core@1.3.1)(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0)
+        version: 1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0)(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0(esbuild@0.25.2))
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -1208,6 +1211,13 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
@@ -6075,6 +6085,12 @@ packages:
       eslint: '>=8.0.0'
       jsonc-eslint-parser: ^2.0.0
 
+  eslint-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411:
+    resolution: {integrity: sha512-R7ncuwbCPFAoeMlS56DGGSJFxmRtlWafYH/iWyep5Ks0RaPqTCL4k5gA87axUBBcITsaIgUGkbqAxDxl8Xfm5A==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
+
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
     engines: {node: '>=10'}
@@ -6773,6 +6789,12 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hookified@1.8.1:
     resolution: {integrity: sha512-GrO2l93P8xCWBSTBX9l2BxI78VU/MAAYag+pG8curS3aBGy0++ZlxrQ7PdUOUVMbn5BwkGb6+eRrnf43ipnFEA==}
@@ -11465,6 +11487,14 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/traverse': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-create-class-features-plugin': 7.27.0(@babel/core@7.26.10)
+      '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
       - supports-color
 
@@ -17136,6 +17166,18 @@ snapshots:
     transitivePeerDependencies:
       - '@types/estree'
 
+  eslint-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411(eslint@8.57.0):
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/parser': 7.27.0
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.10)
+      eslint: 8.57.0
+      hermes-parser: 0.25.1
+      zod: 3.24.2
+      zod-validation-error: 3.4.0(zod@3.24.2)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-hooks@5.2.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
@@ -18004,6 +18046,12 @@ snapshots:
   he@1.2.0: {}
 
   headers-polyfill@4.0.3: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hookified@1.8.1: {}
 
@@ -21864,7 +21912,7 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@1.0.1(@rsbuild/core@1.3.1)(@rslib/core@0.6.1(typescript@5.8.2))(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@types/react@19.0.12)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2))(typescript@5.8.2):
+  storybook-addon-rslib@1.0.1(@rsbuild/core@1.3.1)(@rslib/core@0.6.1(typescript@5.8.2))(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0)(@types/react@19.0.12)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2))(typescript@5.8.2):
     dependencies:
       '@rsbuild/core': 1.3.1
       '@rslib/core': 0.6.1(typescript@5.8.2)
@@ -21901,12 +21949,12 @@ snapshots:
       - '@rspack/core'
       - '@types/react'
 
-  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0(@swc/helpers@0.5.15))(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0(esbuild@0.25.2)):
+  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0(@swc/helpers@0.5.15))(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.38.0)
       '@rsbuild/core': 1.3.1
       '@storybook/react': 8.6.11(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)
-      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.2)(webpack@5.98.0(esbuild@0.25.2))
+      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.2)(webpack@5.98.0)
       '@types/node': 18.19.84
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -21928,12 +21976,12 @@ snapshots:
       - supports-color
       - webpack
 
-  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0):
+  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.1)(@rspack/core@1.3.0)(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(@types/react@19.0.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.38.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)(webpack@5.98.0(esbuild@0.25.2)):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.38.0)
       '@rsbuild/core': 1.3.1
       '@storybook/react': 8.6.11(@storybook/test@8.6.11(storybook@8.6.11(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.11(prettier@3.5.3))(typescript@5.8.2)
-      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.2)(webpack@5.98.0)
+      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.2)(webpack@5.98.0(esbuild@0.25.2))
       '@types/node': 18.19.84
       find-up: 5.0.0
       magic-string: 0.30.17


### PR DESCRIPTION
In preparation for [React Compiler](https://react.dev/learn/react-compiler), we should add the ESLint rule (as warning) to ensure our codebase is ready for it!

Source: https://react.dev/learn/react-compiler#installing-eslint-plugin-react-compiler